### PR TITLE
Fixed user deletion on upgrade and some smaller service start problems

### DIFF
--- a/keycloak.spec
+++ b/keycloak.spec
@@ -4,7 +4,7 @@
 
 Name:           keycloak
 Version:        3.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Keycloak is an open source identity and access management solution.
 
 Group:          System Environment/Base
@@ -51,8 +51,17 @@ exit 0
 %systemd_preun %{name}.service
 
 %postun
-getent passwd %{name} >/dev/null && userdel %{name}
-getent group %{name} >/dev/null && groupdel %{name}
+case "$1" in
+  0)
+    # This is an uninstallation.
+    systemctl disable %{name}.service
+    getent passwd %{name} >/dev/null && userdel %{name}
+    getent group %{name} >/dev/null && groupdel %{name}
+  ;;
+  1)
+    # This is an upgrade.
+  ;;
+esac
 %systemd_postun_with_restart %{name}.service
 
 %clean
@@ -68,6 +77,8 @@ rm -rf %{buildroot}
 %doc %{_docdir}/%{name}/LICENSE
 
 %changelog
+* Fri Jun 30 2017 Fabian Schlier <mail@fabian-schlier.de> - 3.1.0-2
+- Added logic to avoid user/group deletion on update. Due to the fact that during an update the postun section of the old rpm is called, this fix starts working after two upgrades.
 * Thu Jun 01 2017 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 3.1.0-1
 - Initial packaing source.
 

--- a/keycloak.spec
+++ b/keycloak.spec
@@ -4,7 +4,7 @@
 
 Name:           keycloak
 Version:        3.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Keycloak is an open source identity and access management solution.
 
 Group:          System Environment/Base
@@ -36,6 +36,7 @@ ln -sf %{name}-%{version}.Final %{buildroot}%{jboss_home}/%{name}
 install -D %{SOURCE1} %{buildroot}/%{_unitdir}/%{name}.service
 install -D %{SOURCE2} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
 install -D %{SOURCE3} %{buildroot}/%{_docdir}/%{name}/LICENSE
+mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
 
 %pre
 getent group %{name} >/dev/null || groupadd -r %{name}
@@ -75,8 +76,11 @@ rm -rf %{buildroot}
 %attr(644, root, root) %{_unitdir}/%{name}.service
 %config(noreplace) %attr(640, root, %{name}) %{_sysconfdir}/sysconfig/%{name}
 %doc %{_docdir}/%{name}/LICENSE
+%dir %attr(-, %{name}, %{name}) %{_sharedstatedir}/%{name}
 
 %changelog
+* Wed Jul 05 2017 Fabian Schlier <mail@fabian-schlier.de> - 3.1.0-3
+- Added var/lib/keycloak directory to spec to avoid service start problems with missing directory
 * Fri Jun 30 2017 Fabian Schlier <mail@fabian-schlier.de> - 3.1.0-2
 - Added logic to avoid user/group deletion on update. Due to the fact that during an update the postun section of the old rpm is called, this fix starts working after two upgrades.
 * Thu Jun 01 2017 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 3.1.0-1

--- a/keycloak.spec
+++ b/keycloak.spec
@@ -81,6 +81,7 @@ rm -rf %{buildroot}
 %changelog
 * Wed Jul 05 2017 Fabian Schlier <mail@fabian-schlier.de> - 3.1.0-3
 - Added var/lib/keycloak directory to spec to avoid service start problems with missing directory
+- Switched sysconfig opts from -key value to -key=value syntax to avoid problems when starting on RHEL7
 * Fri Jun 30 2017 Fabian Schlier <mail@fabian-schlier.de> - 3.1.0-2
 - Added logic to avoid user/group deletion on update. Due to the fact that during an update the postun section of the old rpm is called, this fix starts working after two upgrades.
 * Thu Jun 01 2017 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 3.1.0-1

--- a/keycloak.spec
+++ b/keycloak.spec
@@ -55,7 +55,6 @@ exit 0
 case "$1" in
   0)
     # This is an uninstallation.
-    systemctl disable %{name}.service
     getent passwd %{name} >/dev/null && userdel %{name}
     getent group %{name} >/dev/null && groupdel %{name}
   ;;

--- a/keycloak.sysconfig
+++ b/keycloak.sysconfig
@@ -4,4 +4,4 @@
 #JBOSS_LOG_DIR=/opt/jboss/keycloak/standalone/log
 JAVA_OPTS=-Xms1024m -Xmx20480m -XX:MaxPermSize=768m
 
-EXTRA_OPTS=-b 0.0.0.0
+EXTRA_OPTS=-b=0.0.0.0


### PR DESCRIPTION
Hi,

the current postun sections deletes the user/group on upgrades. A bit annoying is that my fix starts working after a second upgrade, as the old rpms postun section is executed on upgrade... So probably there must be another release of this to start working.

PS: Thanks for packaging keycloak!

Cheers,
Fabian